### PR TITLE
Chunk Outline Update: The chunk outline now matches the format described in prompt of '_find_relevant_chunk'

### DIFF
--- a/tutorials/LevelsOfTextSplitting/agentic_chunker.py
+++ b/tutorials/LevelsOfTextSplitting/agentic_chunker.py
@@ -238,7 +238,7 @@ class AgenticChunker:
         chunk_outline = ""
 
         for chunk_id, chunk in self.chunks.items():
-            single_chunk_string = f"""Chunk ({chunk['chunk_id']}): {chunk['title']}\nSummary: {chunk['summary']}\n\n"""
+            single_chunk_string = f"""Chunk ID: {chunk['chunk_id']}\nChunk Name: {chunk['title']}\nChunk Summary: {chunk['summary']}\n\n"""
         
             chunk_outline += single_chunk_string
         


### PR DESCRIPTION
<h4>The chunker works like a charm. Just a minor change.</h4>

In the function `_find_relevant_chunk()`: The LLM couldn't extract the `chunk_id`. Instead, it kept extracting `chunk_title`.

Upon inspection, I found that the structure in `get_chunk_outline()` didn't match the structure described in PROMPT of `_find_relevant_chunk()`.

The previous code was tried with following LLMs:
- Llama3
- Phi3
- Mistral7B
